### PR TITLE
Adjust author field validation

### DIFF
--- a/src/components/MetadataFormFields/index.tsx
+++ b/src/components/MetadataFormFields/index.tsx
@@ -12,7 +12,12 @@ export const MetadataFormFields: FC<MetadataFormFieldsProps> = ({ control }) => 
     <div className="space-y-6">
       <InputFormField control={control} name="name" label="Name" placeholder="App name" />
 
-      <InputFormField control={control} name="author" label="Author" placeholder="John Doe" />
+      <InputFormField
+        control={control}
+        name="author"
+        label="Author"
+        placeholder="John Doe <john@example.com>"
+      />
 
       <InputFormField
         control={control}

--- a/src/pages/CreateApp/templates.tsx
+++ b/src/pages/CreateApp/templates.tsx
@@ -27,7 +27,7 @@ type ParsedTemplate = {
 
 const extractMetadata = (parsedTemplate: ParsedTemplate) => ({
   name: parsedTemplate.name || '',
-  author: parsedTemplate.author || '',
+  author: '',
   description: parsedTemplate.description || '',
   version: parsedTemplate.version || '',
   homepage: parsedTemplate.homepage || '',

--- a/src/pages/CreateApp/types.ts
+++ b/src/pages/CreateApp/types.ts
@@ -5,9 +5,12 @@ export const metadataFormSchema = z.object({
   name: z.string().min(1, {
     message: 'Name is required.',
   }),
-  author: z.string().min(1, {
-    message: 'Author is required.',
-  }),
+  author: z.literal('').or(
+    z.string().regex(/^(.+)\s+<([^@\s]+@[^@\s]+\.[^@\s]+)>$/, {
+      message:
+        'Author must follow the format "Name <valid_email>". The email address must be in square brackets',
+    }),
+  ),
   description: z.string().min(1, {
     message: 'Description is required.',
   }),


### PR DESCRIPTION
CLI accepts author only in `Name <email>` format (or empty). Otherwise, build throws `Invalid manifest 'rofl.yaml': malformed author: mail: no angle-addr`