### PR TITLE
Show additional warning in HL Copy Trader machine config

### DIFF
--- a/src/components/BuildForm/index.tsx
+++ b/src/components/BuildForm/index.tsx
@@ -31,6 +31,7 @@ type BuildFormProps = {
     storage: number | undefined
   }
   offerId?: string
+  selectedTemplateId?: string
 }
 
 export const BuildForm: FC<BuildFormProps> = ({
@@ -39,6 +40,7 @@ export const BuildForm: FC<BuildFormProps> = ({
   selectedTemplateRequirements,
   offerId,
   children,
+  selectedTemplateId,
 }) => {
   const network = useNetwork()
   const providersQuery = useGetRuntimeRoflmarketProviders(network, 'sapphire')
@@ -187,6 +189,14 @@ export const BuildForm: FC<BuildFormProps> = ({
                 1 hour is a very short period of time for the app. It may not be enough for debugging.
               </div>
             )}
+            {selectedTemplateId === 'hl-copy-trader' &&
+              ((form.watch('duration') === 'days' && Number(form.watch('number')) < 7) ||
+                (form.watch('duration') === 'hours' && Number(form.watch('number')) < 168)) && (
+                <div className="text-sm text-warning leading-tight mt-2">
+                  We recommend running the Copy Trader for at least 7 days so you have enough time to test it
+                  and withdraw your funds.
+                </div>
+              )}
           </div>
         </div>
 

--- a/src/pages/CreateApp/BuildStep.tsx
+++ b/src/pages/CreateApp/BuildStep.tsx
@@ -46,6 +46,7 @@ export const BuildStep: FC<BuildStepProps> = ({
         onSubmit={onSubmit}
         build={build}
         selectedTemplateRequirements={selectedTemplateRequirements}
+        selectedTemplateId={selectedTemplateId}
       >
         {({ form, handleFormSubmit, noOffersWarning }) => (
           <CreateFormNavigation

--- a/src/pages/CreateApp/templates.tsx
+++ b/src/pages/CreateApp/templates.tsx
@@ -40,6 +40,12 @@ export const defaultBuildConfig = {
   resources: '',
 }
 
+export const defaultCopyTraderBuildConfig = {
+  ...defaultBuildConfig,
+  duration: 'days' as const,
+  number: 7,
+}
+
 const createTemplateParser = (roflData: Record<string, unknown>) => {
   return (metadata: Partial<MetadataFormData>, network: 'mainnet' | 'testnet', appId: string) => {
     return {
@@ -98,7 +104,7 @@ export const templates = [
     id: 'hl-copy-trader',
     initialValues: {
       metadata: extractMetadata(parsedHlTemplate),
-      build: defaultBuildConfig,
+      build: defaultCopyTraderBuildConfig,
     },
     yaml: {
       compose: hlCompose,


### PR DESCRIPTION
TopUp part can be done once we store template id in backend or metadata