### PR TITLE
Auto-refresh machine logs

### DIFF
--- a/src/hooks/useScheduler.ts
+++ b/src/hooks/useScheduler.ts
@@ -11,7 +11,7 @@ export const useScheduler = (schedulerRak: string, provider: string) => {
   const schedulerInstance = schedulerId
     ? schedulerData?.data?.instances.find(instance => instance.rak === schedulerRak)
     : undefined
-  const api = schedulerInstance?.metadata?.['net.oasis.scheduler.api'] as string
+  const api = schedulerInstance?.metadata?.['net.oasis.scheduler.api'] as string | undefined
 
   return {
     api,

--- a/src/pages/Dashboard/MachinesDetails/MachineLogs.tsx
+++ b/src/pages/Dashboard/MachinesDetails/MachineLogs.tsx
@@ -11,29 +11,19 @@ type MachineLogsProps = {
   schedulerRak: string
   provider: string
   instance: string
-  logs: string[]
-  setLogs: (logs: string[]) => void
   isRemoved?: boolean
 }
 
-export const MachineLogs: FC<MachineLogsProps> = ({
-  schedulerRak,
-  provider,
-  instance,
-  logs,
-  setLogs,
-  isRemoved,
-}) => {
+export const MachineLogs: FC<MachineLogsProps> = ({ schedulerRak, provider, instance, isRemoved }) => {
   const { api: schedulerApi } = useScheduler(schedulerRak, provider)
-  const { fetchMachineLogs, isAuthenticating, isLoadingLogs } = useMachineAccess(
+  const { startFetchingMachineLogs, isAuthenticating, isLoadingLogs, logs } = useMachineAccess(
     schedulerApi,
     provider,
     instance,
   )
   const handleFetchLogs = async () => {
     try {
-      const fetchedLogs = await fetchMachineLogs()
-      setLogs(fetchedLogs)
+      await startFetchingMachineLogs()
     } catch (error) {
       console.error('Failed to fetch machine logs:', error)
     }

--- a/src/pages/Dashboard/MachinesDetails/index.tsx
+++ b/src/pages/Dashboard/MachinesDetails/index.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC } from 'react'
+import { type FC } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@oasisprotocol/ui-library/src/components/ui/tabs'
 import { CircleArrowUp, Clock } from 'lucide-react'
@@ -22,7 +22,6 @@ import { toastWithDuration } from '../../../utils/toastWithDuration'
 import { isMachineRemoved } from '../../../components/MachineStatusIcon/isMachineRemoved'
 
 export const MachinesDetails: FC = () => {
-  const [logs, setLogs] = useState<string[]>([])
   const network = useNetwork()
   const { provider, id } = useParams()
   const roflMachinesQuery = useGetRuntimeRoflmarketProvidersAddressInstancesId(
@@ -143,8 +142,6 @@ export const MachinesDetails: FC = () => {
                 schedulerRak={machine.metadata['net.oasis.scheduler.rak'] as string}
                 provider={machine.provider}
                 instance={machine.id}
-                logs={logs}
-                setLogs={setLogs}
                 isRemoved={isMachineRemoved(machine)}
               />
             )}


### PR DESCRIPTION
A drawback of this is that navigating away and back loses token. Ideally token would be persisted per schedulerApi&provider and reused until expiration