### PR TITLE
Tweak app resources row

### DIFF
--- a/src/pages/Dashboard/AppDetails/AppMetadata.tsx
+++ b/src/pages/Dashboard/AppDetails/AppMetadata.tsx
@@ -96,7 +96,7 @@ export const AppMetadata: FC<AppMetadataProps> = ({
           </DetailsSectionRow>
           <DetailsSectionRow label="Resources" className=" pb-6 border-b">
             {machines.map((machine, index) => (
-              <span key={machine.id}>
+              <span key={machine.id} className="flex items-center">
                 <MachineResources
                   cpus={machine.resources.cpus}
                   memory={machine.resources.memory}


### PR DESCRIPTION
We don't have designs how to handle multiple resources so for now applying small CSS fix

master
<img width="618" height="283" alt="Screenshot from 2025-07-25 10-46-51" src="https://github.com/user-attachments/assets/f15e94d9-ffdc-4a89-a584-4f09a74d7ee7" />
vs
<img width="618" height="283" alt="Screenshot from 2025-07-25 10-46-17" src="https://github.com/user-attachments/assets/0f327215-d1c6-4fff-b466-7e6397fe77f5" />
