### PR TITLE
Create Renovate custom manager to update template oasis-boot deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,5 +26,16 @@
       "rangeStrategy": "auto"
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["templates/*/rofl-template.yaml"],
+      "matchStrings": [
+        "https://github.com/oasisprotocol/oasis-boot/releases/download/(?<currentValue>v\\d+\\.\\d+\\.\\d+)/[^#]+#(?<currentDigest>[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "github-release-attachments",
+      "depNameTemplate": "oasisprotocol/oasis-boot"
+    }
+  ],
   "rangeStrategy": "bump"
 }


### PR DESCRIPTION
Part of https://github.com/oasisprotocol/rofl-app/issues/211

This is not super reliable probably because of a bug in Renovate. Renovate has some PRs and issues around digest val.

sample fork output: https://github.com/buberdds/rofl-app/pull/40/files

1) compared to https://github.com/oasisprotocol/rofl-app/commit/892d0065404efccabdf63b0049582f713a5c1bff
`firmware`: val is not correct (when digest is not changed - maybe https://github.com/renovatebot/renovate/pull/35656 ? )
`kernel` and `stage2` are fine 

2) oasis-sdk entry (monorepo) needs more testing so it's not included in this PR

3) ~Renovate is not added to this repo yet~