### PR TITLE
Fix renovate by enabling cloneSubmodules option

### DIFF
--- a/.changelog/334.internal.md
+++ b/.changelog/334.internal.md
@@ -1,0 +1,1 @@
+Fix renovate by enabling cloneSubmodules option

--- a/renovate.json
+++ b/renovate.json
@@ -48,5 +48,6 @@
       "depNameTemplate": "oasisprotocol/oasis-boot"
     }
   ],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "cloneSubmodules": true
 }


### PR DESCRIPTION
Related https://github.com/oasisprotocol/rose-app/pull/307

Right now renovate is creating pullrequests that remove 1000 lines from lockfile
https://github.com/oasisprotocol/rofl-app/pull/327/commits/7c94e084edf67e4dc8702d6311bb868ef1960c1f

`"cloneSubmodules": true` fixes it